### PR TITLE
Allow all php 7.* versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.6,<=7.2",
+        "php": ">=5.6,<=7.3",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.6,<=7.3",
+        "php": "^5.6||7.*",
         "psr/http-message": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi there!

We are using your package in a project which we wanted to update to php7.3 and had the problem, as you may see in the changes, that the composer.json only allows php7.2 and lower, so we forked it and tested if it still works. We had to do some old style testing, as there unfortunately are no unit tests. However, those tests were successful in php 7.3 and I also tried 7.4 which resulted in no errors as well.

I would appreciate if this change would be pulled into your project and a new version get's released, so others may also benefit from it.