### PR TITLE
Allow custom guzzle options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.6,<=7.2",
+        "php": ">=5.6,<=7.3",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.6,<=7.3",
+        "php": "^5.6||7.*",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1"
+        "phpunit/phpunit": "^5.7||^7.1",
+        "guzzlehttp/guzzle": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -19,10 +19,11 @@ class ClientFactory
      * @param string      $host            Rundeck host
      * @param string      $tokenOrUsername API token or Rundeck's user name
      * @param string|null $password        Use if you want a password authentication
+     * @param array       $guzzleConfig    Custom Guzzle config
      *
      * @return Client
      */
-    public static function createClient($host, $tokenOrUsername, $password = null)
+    public static function createClient($host, $tokenOrUsername, $password = null, array $guzzleConfig = [])
     {
         if ($password) {
             $auth = new PasswordAuthentication($host, $tokenOrUsername, $password);
@@ -30,7 +31,7 @@ class ClientFactory
             $auth = new TokenAuthentication($tokenOrUsername);
         }
 
-        $httpClient = new Guzzle6HttpClient($auth);
+        $httpClient = new Guzzle6HttpClient($auth, $guzzleConfig);
 
         return new Client($host, $httpClient);
     }

--- a/src/HttpClient/Guzzle6HttpClient.php
+++ b/src/HttpClient/Guzzle6HttpClient.php
@@ -27,8 +27,9 @@ class Guzzle6HttpClient implements HttpClientInterface
      * Guzzle6HttpHandler constructor.
      *
      * @param AuthenticationInterface $auth
+     * @param array $config Custom Guzzle option array
      */
-    public function __construct(AuthenticationInterface $auth)
+    public function __construct(AuthenticationInterface $auth, array $config = [])
     {
         $stack = new HandlerStack();
         $stack->setHandler(new CurlHandler());
@@ -38,7 +39,17 @@ class Guzzle6HttpClient implements HttpClientInterface
             };
         });
 
-        $this->client = new HttpClient(['handler' => $stack]);
+        $config = array_merge([
+            'handler'           => $stack,
+            'headers'           => [
+                'Content-Type'  => 'application/json',
+                'Accept'        => 'application/json',
+            ],
+            'connect_timeout'   => 10,
+            'timeout'           => 10,
+        ], $config);
+
+        $this->client = new HttpClient($config);
     }
 
     /**
@@ -49,13 +60,7 @@ class Guzzle6HttpClient implements HttpClientInterface
     public function request($method, $uri, array $json = [])
     {
         return $this->client->request($method, $uri, [
-            'headers'         => [
-                'Content-Type' => 'application/json',
-                'Accept'       => 'application/json',
-            ],
-            'connect_timeout' => 10,
-            'timeout'         => 10,
-            'json'            => $json
+            'json' => $json
         ]);
     }
 


### PR DESCRIPTION
Hi there,

I had to find a way to set a higher timeout limit for the Rundeck request and that's when I saw that it's actually hardcoded. I changed it in a way, that the Guzzle config remains the same for every request, but you have the option to overwrite it via the Client or Client Factory.