### PR TITLE
Add support for php 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2, 7.1, 7.0, 5.6]
+        php: [8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        php: [7.4, 7.3, 7.2, 7.1, 7.0, 5.6]
+        dependency-version: [prefer-lowest, prefer-stable]
+        os: [ubuntu-latest]
+
+    name: php ${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.6||7.*",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7||^7.1",
+        "symfony/phpunit-bridge": "^5.2",
         "guzzlehttp/guzzle": "^6.5"
     },
     "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -14,6 +14,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class Client
 {
+    /**
+     * @var string
+     */
     private $baseUrl;
 
     /**


### PR DESCRIPTION
Based on #3 this pull request adds support for php 8. I replaced phpunit by the `symfony/phpunit-bridge` as this package makes it easier to support unit tests for php `5.6 => 8.0`.