### PR TITLE
Add Scheduled State to JobRunner

### DIFF
--- a/src/Entity/JobExecutionEntity.php
+++ b/src/Entity/JobExecutionEntity.php
@@ -16,6 +16,8 @@ class JobExecutionEntity
 
     const STATE_FAILED = 'failed';
 
+    const STATE_SCHEDULED = 'scheduled';
+
     /**
      * @var string
      */

--- a/src/Execution/JobRunner.php
+++ b/src/Execution/JobRunner.php
@@ -131,7 +131,10 @@ class JobRunner
 
         $averageDuration = max(ceil($this->execution->getJob()->getAverageDuration() / 1000), 1);
 
-        while ($this->execution->getStatus() === JobExecutionEntity::STATE_RUNNING) {
+        while (
+            $this->execution->getStatus() === JobExecutionEntity::STATE_RUNNING
+            || $this->execution->getStatus() === JobExecutionEntity::STATE_SCHEDULED
+        ) {
             if ($executionTime > $this->executionTimeout) {
                 $exception = new JobExecutionTimeoutExceededException(
                     "The maximum job execution timeout of {$this->executionTimeout} seconds have been exceeded"


### PR DESCRIPTION
This PR adds the Scheduled State to the JobRunner. This is needed if you stack up multiple executions of the same job, otherwise the Runner will instantly fail.